### PR TITLE
Address wrapping issue on narrow screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -51,7 +51,8 @@ body {
   left: 0;
   bottom: 0;
   width: 100%;
-  height: 20%; /* Caption covers bottom portion of image */
+  min-height: 2.5em;
+  max-height: 60%;
   background: rgba(171, 20, 0, 0.85);
   color: #fff;
   font-size: 1em;
@@ -64,7 +65,11 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  text-align: center; 
+  text-align: center;
+  overflow-y: auto;
+  white-space: normal;
+  word-break: break-word;
+  z-index: 2;
 }
 
 .gallery-item:hover .gallery-caption {
@@ -346,4 +351,24 @@ a:hover {
   height: auto;
   margin: 0 auto 1.5em auto;
   display: block;
+}
+
+/* Make gallery images stack in a single column on mobile */
+@media (max-width: 700px) {
+  .gallery-item,
+  .gallery-grid img {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    margin-bottom: 0;
+  }
+  .gallery-grid {
+    gap: 16px;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+  .gallery-container {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
 }


### PR DESCRIPTION
On wider screens:
<img width="678" height="892" alt="Screenshot 2025-10-01 at 6 15 57 PM" src="https://github.com/user-attachments/assets/13ceef21-4efb-4101-8b99-0bbc6811f233" />

On narrower screens:
<img width="269" height="898" alt="Screenshot 2025-10-01 at 6 15 46 PM" src="https://github.com/user-attachments/assets/ffa621c9-d58c-4e98-a22c-acb05954e6bc" />
